### PR TITLE
Parse volumes as ERB templates

### DIFF
--- a/lib/dockershell.rb
+++ b/lib/dockershell.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'open3'
+require 'erb'
 
 class Dockershell
   def initialize(options)
@@ -102,7 +103,7 @@ private
     ]
 
     @options[:profile][:volumes].each do |volume|
-      args << '--volume' << volume
+      args << '--volume' << ERB.new(volume).result(binding)
     end
 
     args << @options[:profile][:image] << '/sbin/init'


### PR DESCRIPTION
This allows using @options[:name] when mapping the environment